### PR TITLE
Add ability to return full list of teams paired with bye weeks

### DIFF
--- a/src/FFNerd.php
+++ b/src/FFNerd.php
@@ -42,7 +42,11 @@ class FFNerd extends ApiRequest
       return $this->collectionRequest('players', 'Players');
   }
 
-  public function byes($week) {
+  public function byes($week = null) {
+      if ( $week == null) {
+          return $this->collectionRequest('byes');
+      }
+
       if (($week < 4) || ($week > 12)) {
           throw OutOfRange::create();
       }
@@ -120,4 +124,6 @@ class FFNerd extends ApiRequest
   public function depthCharts() {
       return $this->collectionRequest('depth-charts', 'DepthCharts');
   }
+
+
 }

--- a/test/FFNerdTest.php
+++ b/test/FFNerdTest.php
@@ -90,6 +90,13 @@ class FFNerdTest extends TestCase
   }
 
   /** @test */
+  public function it_should_return_all_weeks_and_teams_with_byes() {
+      $byeTeams = $this->f->byes();
+      $this->assertCount(9, $byeTeams);
+      $this->assertEquals('CAR', $byeTeams->first()[0]['team']);
+  }
+
+  /** @test */
   public function it_should_return_a_collection_of_auction_values() {
       $auction = $this->f->auctionValues();
       $this->assertEquals('100', $auction->first()['SalaryCap']);


### PR DESCRIPTION
In order to return the full list of the current year's bye weeks paired
with the team, this commit allows the `byes` function to not take a
parameter.